### PR TITLE
Remove ignored columns from attribute_names

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,16 @@
+require 'rubygems'
+require 'rake'
+
+desc 'Default: run unit tests.'
+task :default => :test
+
+begin
+  require 'rspec'
+  require 'rspec/core/rake_task'
+  desc 'Run the unit tests'
+  RSpec::Core::RakeTask.new(:test)
+rescue LoadError
+  task :test do
+    STDERR.puts "You must have rspec 2.0 installed to run the tests"
+  end
+end

--- a/ignorable.gemspec
+++ b/ignorable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "ignorable"
-  s.version     = "0.1.0"
+  s.version     = "0.2.0"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nathaniel Jones", "Mando Escamilla"]
   s.email       = ["hello@nthj.me", ""]
@@ -11,7 +11,9 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ignorable"
  
-  s.add_dependency("rails", ">= 3")
+  s.add_dependency("activerecord", ">= 3")
+  s.add_development_dependency("sqlite3", ">= 0")
+  s.add_development_dependency("rspec", ">= 2.0.0")
 
   s.files        = Dir.glob("{lib}/**/*") + %w(README.md)
   s.require_path = 'lib'

--- a/lib/ignorable.rb
+++ b/lib/ignorable.rb
@@ -1,46 +1,52 @@
+require 'active_record'
+
 module Ignorable
-  def columns
-    @columns ||= super.reject do |col|
-      self.ignored_column?(col)
+  extend ActiveSupport::Concern
+  
+  def attribute_names # :nodoc:
+    super.reject{|col| self.class.ignored_column?(col)}
+  end
+
+  module ClassMethods
+    def columns # :nodoc:
+      @columns ||= super.reject{|col| ignored_column?(col)}
     end
-  end
 
-  attr_reader :ignored_columns
+    attr_reader :ignored_columns
 
-  # Prevent Rails from loading a table column.
-  # Useful for legacy database schemas with problematic column names,
-  # like 'class' or 'attributes'.
-  #
-  #   class Topic < ActiveRecord::Base
-  #     ignore_columns :attributes, :class
-  #   end
-  #
-  #   Topic.new.respond_to?(:attributes) => false
-  def ignore_columns *columns
-    @ignored_columns ||= []
-    @ignored_columns += columns.map(&:to_s)
-    reset_column_information
-    @ignored_columns.tap(&:uniq!)
-  end
-  alias ignore_column ignore_columns
+    # Prevent Rails from loading a table column.
+    # Useful for legacy database schemas with problematic column names,
+    # like 'class' or 'attributes'.
+    #
+    #   class Topic < ActiveRecord::Base
+    #     ignore_columns :attributes, :class
+    #   end
+    #
+    #   Topic.new.respond_to?(:attributes) => false
+    def ignore_columns(*columns)
+      @ignored_columns ||= []
+      @ignored_columns += columns.map(&:to_s)
+      reset_column_information
+      @ignored_columns.tap(&:uniq!)
+    end
+    alias ignore_column ignore_columns
 
-  # Has a column been ignored?
-  # Accepts both ActiveRecord::ConnectionAdapter::Column objects,
-  # and actual column names ('title')
-  def ignored_column? column
-    ignored_columns.present? && ignored_columns.include?(
-      column.respond_to?(:name) ? column.name : column.to_s
-    )
-  end
+    # Has a column been ignored?
+    # Accepts both ActiveRecord::ConnectionAdapter::Column objects,
+    # and actual column names ('title')
+    def ignored_column?(column)
+      ignored_columns.present? && ignored_columns.include?(
+        column.respond_to?(:name) ? column.name : column.to_s
+      )
+    end
 
-  def reset_ignored_columns
-    @ignored_columns = []
-    reset_column_information
+    def reset_ignored_columns
+      @ignored_columns = []
+      reset_column_information
+    end
   end
 end
 
-require 'rails'
-
-if defined?(ActiveRecord::Base)
-  ActiveRecord::Base.send :extend, Ignorable
+if defined?(ActiveRecord::Base) && !ActiveRecord::Base.include?(Ignorable)
+  ActiveRecord::Base.send :include, Ignorable
 end

--- a/spec/ignorable_spec.rb
+++ b/spec/ignorable_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Ignorable do
+  
+  class TestModel < ActiveRecord::Base
+    connection.create_table :test_models do |t|
+      t.string :name
+      t.string :attributes
+      t.integer :legacy
+    end unless table_exists?
+    
+    ignore_columns :legacy, :attributes
+    has_many :things
+  end
+  
+  class Thing < ActiveRecord::Base
+    connection.create_table :things do |t|
+      t.integer :test_model_id
+      t.integer :value
+      t.datetime :updated_at
+      t.datetime :created_at
+    end unless table_exists?
+    
+    ignore_column :updated_at, :created_at
+    belongs_to :test_model
+  end
+  
+  around :each do |example|
+    ActiveRecord::Base.transaction do
+      example.call
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  it "should remove the columns from the class" do
+    TestModel.column_names.sort.should == ["id", "name"]
+    Thing.column_names.sort.should == ["id", "test_model_id", "value"]
+  end
+  
+  it "should remove the columns from the attribute names" do
+    TestModel.new.attribute_names.sort.should == ["id", "name"]
+    Thing.new.attribute_names.sort.should == ["id", "test_model_id", "value"]
+  end
+  
+  it "should remove the accessor methods" do
+    TestModel.new.should_not respond_to(:updated_at)
+    TestModel.new.should_not respond_to(:updated_at=)
+  end
+  
+  it "should not override existing methods with ignored column accessors" do
+    model = TestModel.new
+    model.attributes.should == {"id" => nil, "name" => nil}
+    model.attributes = {:name => "test"}
+    model.name.should == "test"
+  end
+  
+  it "should not affect inserts" do
+    model = TestModel.create!(:name => "test")
+    model.reload
+    model.name.should == "test"
+    model.attributes["legacy"].should == nil
+  end
+  
+  it "should not affect selects" do
+    TestModel.connection.insert("INSERT INTO test_models (name, legacy, attributes) VALUES ('test', 1, 'woo')")
+    model = TestModel.where(:name => "test").first
+    model.name.should == "test"
+    model.attributes["legacy"].should == nil
+    model.attributes["attributes"].should == nil
+  end
+  
+  it "should not affect updates" do
+    TestModel.connection.insert("INSERT INTO test_models (name, legacy, attributes) VALUES ('test', 1, 'woo')")
+    model = TestModel.where(:name => "test").first
+    model.name = "test2"
+    model.save!
+    results = TestModel.connection.select_one("SELECT name, legacy, attributes from test_models where name = 'test2'")
+    results.should == {"name"=>"test2", "legacy" => 1, "attributes" => "woo"}
+  end
+  
+  it "should work with associations" do
+    TestModel.connection.insert("INSERT INTO test_models (id, name, legacy, attributes) VALUES (1, 'test', 1, 'woo')")
+    Thing.connection.insert("INSERT INTO things (id, test_model_id, value, updated_at, created_at) VALUES (1, 1, 10, '#{Time.now.to_formatted_s(:db)}', '#{Time.now.to_formatted_s(:db)}')")
+    model = TestModel.create!(:name => "test")
+    thing = Thing.create!(:test_model_id => model.id, :value => 10)
+    model.things.first.value.should == 10
+    thing.test_model.name.should == "test"
+  end
+  
+  it "should work with magic timestamp columns" do
+    thing = Thing.create!(:test_model_id => 1, :value => 10)
+    results = Thing.connection.select_one("SELECT id, value, test_model_id, updated_at, created_at FROM things where id = #{thing.id}")
+    results.should == {"id" => 1, "value" => 10, "test_model_id" => 1, "updated_at" => nil, "created_at" => nil}
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'rubygems'
+
+active_record_version = ENV["ACTIVE_RECORD_VERSION"] || [">=3.0.0"]
+active_record_version = [active_record_version] unless active_record_version.is_a?(Array)
+gem 'activerecord', *active_record_version
+
+require 'active_record'
+puts "Testing Against ActiveRecord #{ActiveRecord::VERSION::STRING}"
+
+ActiveRecord::Base.establish_connection("adapter" => "sqlite3", "database" => ":memory:")
+
+require File.expand_path("../../lib/ignorable.rb", __FILE__)


### PR DESCRIPTION
I ran into a problem with associations which uses the attributes_names instance methods and resulted in a lots of deprecation warnings from ActiveRecord.

This patch fixes the error by applying ignored_column? logic to attribute names. I refactored slightly to use ActiveSupport::Concern since the module now mixes both instance and class methods.

I also added an rspec test suite and Rakefile and bumped the version to 0.2.0 in the gemspec.

One other thing that is missing is a license file. Could you please add one to make the world's lawyers happy :-)
