### PR TITLE
Ignore columns in subclasses too

### DIFF
--- a/lib/ignorable.rb
+++ b/lib/ignorable.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'active_support/core_ext/class/attribute'
 
 module Ignorable
   extend ActiveSupport::Concern
@@ -7,12 +8,14 @@ module Ignorable
     super.reject{|col| self.class.ignored_column?(col)}
   end
 
+  included do
+    class_attribute :ignored_columns
+  end
+
   module ClassMethods
     def columns # :nodoc:
       @columns ||= super.reject{|col| ignored_column?(col)}
     end
-
-    attr_reader :ignored_columns
 
     # Prevent Rails from loading a table column.
     # Useful for legacy database schemas with problematic column names,
@@ -24,10 +27,11 @@ module Ignorable
     #
     #   Topic.new.respond_to?(:attributes) => false
     def ignore_columns(*columns)
-      @ignored_columns ||= []
-      @ignored_columns += columns.map(&:to_s)
+      self.ignored_columns ||= []
+      self.ignored_columns += columns.map(&:to_s)
       reset_column_information
-      @ignored_columns.tap(&:uniq!)
+      descendants.each(&:reset_column_information)
+      self.ignored_columns.tap(&:uniq!)
     end
     alias ignore_column ignore_columns
 
@@ -35,13 +39,13 @@ module Ignorable
     # Accepts both ActiveRecord::ConnectionAdapter::Column objects,
     # and actual column names ('title')
     def ignored_column?(column)
-      ignored_columns.present? && ignored_columns.include?(
+      self.ignored_columns.present? && self.ignored_columns.include?(
         column.respond_to?(:name) ? column.name : column.to_s
       )
     end
 
     def reset_ignored_columns
-      @ignored_columns = []
+      self.ignored_columns = []
       reset_column_information
     end
   end

--- a/spec/ignorable_spec.rb
+++ b/spec/ignorable_spec.rb
@@ -24,7 +24,10 @@ describe Ignorable do
     ignore_column :updated_at, :created_at
     belongs_to :test_model
   end
-  
+
+  class SubclassTestModel < TestModel
+  end
+
   around :each do |example|
     ActiveRecord::Base.transaction do
       example.call
@@ -36,7 +39,34 @@ describe Ignorable do
     TestModel.column_names.sort.should == ["id", "name"]
     Thing.column_names.sort.should == ["id", "test_model_id", "value"]
   end
-  
+
+  it 'removes columns from the subclass' do
+    expect(SubclassTestModel.column_names).to match_array(['id', 'name'])
+  end
+
+  context 'when ignore_columns is called after the columns are loaded' do
+    before do
+      @test_model = Class.new(ActiveRecord::Base) do
+        self.table_name = 'test_models'
+      end
+      @subclass = Class.new(@test_model)
+
+      # Force columns to load
+      @test_model.columns
+      @subclass.columns
+
+      @test_model.ignore_columns :attributes, :legacy
+    end
+
+    it 'removes columns from the class' do
+      expect(@test_model.column_names).to match_array(['id', 'name'])
+    end
+
+    it 'removes columns from the subclass' do
+      expect(@subclass.column_names).to match_array(['id', 'name'])
+    end
+  end
+
   it "should remove the columns from the attribute names" do
     TestModel.new.attribute_names.sort.should == ["id", "name"]
     Thing.new.attribute_names.sort.should == ["id", "test_model_id", "value"]


### PR DESCRIPTION
This change allows ignore_columns calls on a class to work on its subclasses too (for cases like single table inheritance).