### PR TITLE
Don't allow ignored attributes to be dynamically defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ Usage
        ignore_columns :attributes, :class, :meta_column_used_by_another_app
     end
 
+
+Running Tests
+==============
+
+Run `rake default` to test against all rails versions
+
 Rails Versions
 ==============
 
-Tested on Rails 3.2, Rails 4.1.0.
+Tested on Rails 3.2, Rails 4.0, and Rails 4.2.
 
 This gem is not needed on Rails 5.0 because an `ignored_columns` feature has
 been merged in https://github.com/rails/rails/pull/21720

--- a/lib/ignorable.rb
+++ b/lib/ignorable.rb
@@ -10,6 +10,14 @@ module Ignorable
     def attribute_names # :nodoc:
       super.reject{|col| self.class.ignored_column?(col)}
     end
+
+    def attribute_method?(attr_name) # :nodoc:
+      if self.class.ignored_column?(attr_name)
+        false
+      else
+        super
+      end
+    end
   end
 
   module ClassMethods

--- a/spec/ignorable_spec.rb
+++ b/spec/ignorable_spec.rb
@@ -78,8 +78,8 @@ describe Ignorable do
   end
 
   it "should remove the accessor methods" do
-    expect(TestModel.new).to_not respond_to(:updated_at)
-    expect(TestModel.new).to_not respond_to(:updated_at=)
+    expect(TestModel.new).to_not respond_to(:legacy)
+    expect(TestModel.new).to_not respond_to(:legacy=)
   end
 
   it "should not override existing methods with ignored column accessors" do
@@ -90,6 +90,16 @@ describe Ignorable do
   end
 
   it "should not affect inserts" do
+    model = TestModel.create!(:name => "test")
+    model.reload
+    expect(model.name).to eql "test"
+    expect(model.attributes["legacy"]).to be_nil
+  end
+
+  it "should not affect inserts if column is dropped" do
+    # Drop column first to make sure it isn't trying to insert NULL into column
+    TestModel.connection.remove_column :test_models, :legacy
+
     model = TestModel.create!(:name => "test")
     model.reload
     expect(model.name).to eql "test"
@@ -126,5 +136,12 @@ describe Ignorable do
     thing = Thing.create!(:test_model_id => 1, :value => 10)
     results = Thing.connection.select_one("SELECT id, value, test_model_id, updated_at, created_at FROM things where id = #{thing.id}")
     expect(results).to eql({"id" => 1, "value" => 10, "test_model_id" => 1, "updated_at" => nil, "created_at" => nil})
+  end
+
+  it "should not allow ignored attributes to be dynamically defined" do
+    TestModel.connection.insert("INSERT INTO test_models (name, legacy, attributes) VALUES ('test', 1, 'woo')")
+    model = TestModel.where(:name => "test").first
+
+    expect { model.legacy }.to raise_error(NoMethodError)
   end
 end


### PR DESCRIPTION
I noticed while adding this gem to our repo that in some cases, Rails still allows you to access ignored columns with attribute getters and setters. To reproduce, retrieve a record from the database and try to access the ignored column. Notice that Rails still returns the actual value for this column instead of raising a NoMethodError.

After doing some digging, it looks like Rails will try to dynamically define attributes even if they've previously been ignored. This PR overrides the `attribute_method?` method to return false for any ignored columns. I added a spec to demonstrate this case.