### PR TITLE
Stop defining attributes methods for ignored columns

### DIFF
--- a/lib/ignorable.rb
+++ b/lib/ignorable.rb
@@ -10,6 +10,16 @@ module Ignorable
     def attribute_names # :nodoc:
       super.reject{|col| self.class.ignored_column?(col)}
     end
+    
+    def attribute_method?(attr_name) # :nodoc:
+      # attribute_method? WAS going through AR:PrimaryKey, then AR:AttributeMethods.  
+      # AR:AttributeMethods uses @attributes... which I'll do too
+      attr_name == "id" ||
+        ( defined?(@attributes) && @attributes.key?(attr_name) &&
+          (ignored_column_list.blank? || !ignored_column_list.include?(attr_name))
+        )
+    end
+
   end
 
   module ClassMethods

--- a/spec/ignorable_spec.rb
+++ b/spec/ignorable_spec.rb
@@ -127,4 +127,9 @@ describe Ignorable do
     results = Thing.connection.select_one("SELECT id, value, test_model_id, updated_at, created_at FROM things where id = #{thing.id}")
     expect(results).to eql({"id" => 1, "value" => 10, "test_model_id" => 1, "updated_at" => nil, "created_at" => nil})
   end
+  
+  it "should not create methods for ignored attributes" do
+    model = TestModel.new
+    expect{ model.legacy = 'old' }.to raise_error(NoMethodError)
+  end
 end


### PR DESCRIPTION
`attribute_method` was using @attributes, presumably due to its use early in initialization.  This ensures that that checks ignored_columns.